### PR TITLE
feat(osman): adopt runtime-first theme configuration

### DIFF
--- a/docs/theme-architecture.md
+++ b/docs/theme-architecture.md
@@ -1,0 +1,77 @@
+# Theme architecture
+
+ThemeJS2 uses four styling layers with intentionally different responsibilities.
+
+## 1. Nextrap base tokens
+
+`--nt-*` describes the design scale and common semantics. New themes should use the runtime token graph from `@nextrap/style-base` so mechanically derived values remain live CSS values.
+
+Typical inputs are brand colors, neutral color, typography, base radius and container width. Hover/active colors, surfaces, borders and radius variants are derived by CSS.
+
+## 2. Theme semantics
+
+`--theme-*` describes only cross-component design language. Keep this set deliberately small.
+
+Examples:
+
+```css
+--theme-corner: var(--nt-radius);
+--theme-corner-small: var(--nt-border-radius-sm);
+--theme-corner-large: var(--nt-border-radius-xl);
+--theme-content-gap: var(--nt-space-4);
+--theme-section-gap: var(--nt-space-7);
+--theme-border: var(--nt-border-width) solid var(--nt-border);
+```
+
+A semantic token should normally have multiple independent consumers. Do not introduce variables such as `--theme-card-header-radius` or `--theme-hero-content-padding`; those duplicate the component structure in a second naming API.
+
+## 3. Component mixins and parts
+
+Use Nextrap mixins for behavior or variants the component already understands. Use exported `::part()` selectors for precise styling.
+
+```scss
+nte-card.style-default {
+  @include card.default-style();
+
+  &::part(wrapper) {
+    border-radius: var(--theme-corner);
+  }
+}
+```
+
+Parts are preferred over adding component custom properties for every possible visual adjustment: the target is explicit and discoverable and authors do not have to guess variable names.
+
+## 4. Customer/project layer
+
+Customer themes should primarily override base inputs or the small semantic layer:
+
+```css
+.theme-customer-square {
+  --nt-primary: #005d75;
+  --theme-corner: 0;
+  --theme-corner-small: 0;
+  --theme-corner-large: 0;
+}
+```
+
+True exceptions can target a part directly:
+
+```css
+.theme-customer-square ntl-hero::part(content) {
+  max-width: 60rem;
+}
+```
+
+## Decision order
+
+1. Change a Nextrap base input when the design scale changes.
+2. Change a `--theme-*` semantic when a cross-component design decision changes.
+3. Use an existing component mixin for a known component variant.
+4. Style an exported `::part()` for a precise component adjustment.
+5. Add raw customer-specific selectors only for genuine exceptions.
+
+Avoid `!important`; fix cascade ownership or component defaults instead where possible.
+
+## Sass vs CSS
+
+Sass remains responsible for selectors, mixin composition, loops/code generation and conditional bundle structure. CSS custom properties are responsible for runtime values and mechanical derivation. This keeps customer configuration runtime-overridable without turning each component into a large custom-property API.

--- a/docs/theme-architecture.md
+++ b/docs/theme-architecture.md
@@ -2,20 +2,46 @@
 
 ThemeJS2 uses four styling layers with intentionally different responsibilities.
 
-## 1. Nextrap base tokens
+## 1. Theme inputs
 
-`--nt-*` describes the design scale and common semantics. New themes should use the runtime token graph from `@nextrap/style-base` so mechanically derived values remain live CSS values.
-
-Typical inputs are brand colors, neutral color, typography, base radius and container width. Hover/active colors, surfaces, borders and radius variants are derived by CSS.
-
-## 2. Theme semantics
-
-`--theme-*` describes only cross-component design language. Keep this set deliberately small.
-
-Examples:
+`--theme-*` is the public, browser-editable configuration of a theme. Brand colors, typography, base radius, container width and similar intentional design choices are defined here.
 
 ```css
---theme-corner: var(--nt-radius);
+.theme-osman {
+  --theme-primary: #2b94d6;
+  --theme-neutral: #6f6f6f;
+  --theme-font-family: "Open Sans", sans-serif;
+  --theme-radius: .5rem;
+  --theme-container-max: 1320px;
+}
+```
+
+Customer overrides and DevTools experiments should normally change these variables, not Nextrap internals.
+
+## 2. Mapping to Nextrap
+
+The theme maps its public inputs onto Nextrap's `--nt-*` inputs:
+
+```css
+--nt-primary: var(--theme-primary);
+--nt-neutral: var(--theme-neutral);
+--nt-font-family: var(--theme-font-family);
+--nt-radius: var(--theme-radius);
+--nt-container-max: var(--theme-container-max);
+```
+
+`@nextrap/style-base` then derives the mechanical design-system values at runtime in CSS: hover/active colors, surfaces, borders, radius variants and similar tokens.
+
+Do not mirror those derived NT values back into theme variables. For example, there should normally be no `--theme-primary-hover` or `--theme-surface-muted`. They are implementation details derived from the public theme inputs.
+
+Directly overriding `--nt-*` is reserved for debugging Nextrap itself or an intentional low-level escape hatch.
+
+## 3. Additional theme semantics
+
+A small number of additional `--theme-*` variables may describe cross-component design language that is not already represented by a public input.
+
+```css
+--theme-corner: var(--theme-radius);
 --theme-corner-small: var(--nt-border-radius-sm);
 --theme-corner-large: var(--nt-border-radius-xl);
 --theme-content-gap: var(--nt-space-4);
@@ -25,7 +51,23 @@ Examples:
 
 A semantic token should normally have multiple independent consumers. Do not introduce variables such as `--theme-card-header-radius` or `--theme-hero-content-padding`; those duplicate the component structure in a second naming API.
 
-## 3. Component mixins and parts
+The runtime flow is therefore:
+
+```text
+Customer / Browser
+      ↓
+--theme-* public inputs
+      ↓
+Theme → Nextrap mapping
+      ↓
+--nt-* inputs
+      ↓
+CSS-derived Nextrap tokens
+      ↓
+Mixins / native defaults / ::part()
+```
+
+## 4. Component mixins and parts
 
 Use Nextrap mixins for behavior or variants the component already understands. Use exported `::part()` selectors for precise styling.
 
@@ -47,8 +89,6 @@ Themes should also define their intended default appearance for native HTML elem
 
 When Nextrap provides a semantic base class for the same element, that base class owns the styling and the theme default must opt out. Check only the base class, not every utility or variant class. Variants are expected to be used together with their base class.
 
-For example:
-
 ```scss
 :where(table:not(.table)) {
   @include elements.table();
@@ -64,38 +104,48 @@ For example:
 }
 ```
 
-This means a plain `<table>` or `<table class="mt-4">` still receives the theme default. A `<table class="table table-striped">` opts into the Nextrap table API because `.table` is present. Likewise, native `ul` and `ol` defaults remain active until `.list` explicitly transfers ownership to the Nextrap list API.
+A plain `<table>` or `<table class="mt-4">` still receives the theme default. A `<table class="table table-striped">` opts into the Nextrap table API because `.table` is present. Likewise, native `ul` and `ol` defaults remain active until `.list` explicitly transfers ownership to the Nextrap list API.
 
 Do not enumerate utility or variant classes in `:not(...)`. Utility classes must remain composable with native defaults, and variants such as table stripes or list styles are subordinate to their semantic base class.
 
-## 4. Customer/project layer
+## Customer/project layer
 
-Customer themes should primarily override base inputs or the small semantic layer:
+A customer normally changes public theme inputs:
 
 ```css
-.theme-customer-square {
-  --nt-primary: #005d75;
-  --theme-corner: 0;
-  --theme-corner-small: 0;
-  --theme-corner-large: 0;
+.theme-customer {
+  --theme-primary: #005d75;
+  --theme-radius: 0;
 }
 ```
 
-True exceptions can target a part directly:
+The Nextrap mapping and all CSS-derived values follow automatically.
+
+A customer may change an additional theme semantic when the desired behavior intentionally differs from the base input:
 
 ```css
-.theme-customer-square ntl-hero::part(content) {
+.theme-customer {
+  --theme-radius: .5rem;
+  --theme-corner: 1rem;
+}
+```
+
+True component-specific exceptions target a part directly:
+
+```css
+.theme-customer ntl-hero::part(content) {
   max-width: 60rem;
 }
 ```
 
 ## Decision order
 
-1. Change a Nextrap base input when the design scale changes.
-2. Change a `--theme-*` semantic when a cross-component design decision changes.
+1. Change a public `--theme-*` input when the theme design changes.
+2. Add or change an additional `--theme-*` semantic only for a repeated cross-component design decision.
 3. Use an existing component mixin for a known component variant.
 4. Style an exported `::part()` for a precise component adjustment.
 5. Add raw customer-specific selectors only for genuine exceptions.
+6. Override `--nt-*` directly only as a low-level escape hatch or while debugging Nextrap.
 
 Avoid `!important`; fix cascade ownership or component defaults instead where possible.
 

--- a/docs/theme-architecture.md
+++ b/docs/theme-architecture.md
@@ -41,6 +41,33 @@ nte-card.style-default {
 
 Parts are preferred over adding component custom properties for every possible visual adjustment: the target is explicit and discoverable and authors do not have to guess variable names.
 
+## Native HTML element defaults
+
+Themes should also define their intended default appearance for native HTML elements. These defaults belong in the theme's `html-elements` layer and should apply to plain semantic markup without requiring utility or component classes.
+
+When Nextrap provides a semantic base class for the same element, that base class owns the styling and the theme default must opt out. Check only the base class, not every utility or variant class. Variants are expected to be used together with their base class.
+
+For example:
+
+```scss
+:where(table:not(.table)) {
+  @include elements.table();
+  @include elements.table-striped();
+}
+
+:where(ul:not(.list)) {
+  // Theme default unordered-list style.
+}
+
+:where(ol:not(.list)) {
+  // Theme default ordered-list style.
+}
+```
+
+This means a plain `<table>` or `<table class="mt-4">` still receives the theme default. A `<table class="table table-striped">` opts into the Nextrap table API because `.table` is present. Likewise, native `ul` and `ol` defaults remain active until `.list` explicitly transfers ownership to the Nextrap list API.
+
+Do not enumerate utility or variant classes in `:not(...)`. Utility classes must remain composable with native defaults, and variants such as table stripes or list styles are subordinate to their semantic base class.
+
 ## 4. Customer/project layer
 
 Customer themes should primarily override base inputs or the small semantic layer:

--- a/theme/osman/_runtime-settings.scss
+++ b/theme/osman/_runtime-settings.scss
@@ -1,0 +1,32 @@
+// Osman runtime theme inputs and deliberately small semantic theme layer.
+//
+// Nextrap `--nt-*` inputs describe the design scale. The `--theme-*` tokens
+// below describe cross-component design language only. Component-specific
+// customization remains in the component partials and should prefer ::part().
+
+--nt-primary: #2b94d6;
+--nt-accent: #2b94d6;
+--nt-neutral: #6f6f6f;
+--nt-secondary: #4c4c4c;
+--nt-tertiary: #17a2b8;
+--nt-success: #28a745;
+--nt-info: #17a2b8;
+--nt-warning: #ffc107;
+--nt-danger: #dc3545;
+
+--nt-font-family: "Open Sans", sans-serif;
+--nt-font-family-header: var(--nt-font-family);
+--nt-font-size: 1rem;
+--nt-line-height: 1.4;
+--nt-radius: .5rem;
+--nt-container-max: 1320px;
+
+// Theme semantics: add only when the same design decision has multiple,
+// independent consumers. Do not mirror component parts as variables.
+--theme-corner: var(--nt-radius);
+--theme-corner-small: var(--nt-border-radius-sm);
+--theme-corner-large: var(--nt-border-radius-xl);
+--theme-content-gap: var(--nt-space-4);
+--theme-section-gap: var(--nt-space-7);
+--theme-border: var(--nt-border-width) solid var(--nt-border);
+--theme-shadow: none;

--- a/theme/osman/_runtime-settings.scss
+++ b/theme/osman/_runtime-settings.scss
@@ -1,29 +1,59 @@
-// Osman runtime theme inputs and deliberately small semantic theme layer.
+// Osman runtime theme configuration.
 //
-// Nextrap `--nt-*` inputs describe the design scale. The `--theme-*` tokens
-// below describe cross-component design language only. Component-specific
-// customization remains in the component partials and should prefer ::part().
+// `--theme-*` is the public, browser-editable theme API.
+// `--nt-*` is the mapping into Nextrap's runtime token graph.
+// Component-specific customization remains in component partials and should
+// prefer mixins and ::part() instead of adding more variables.
 
---nt-primary: #2b94d6;
---nt-accent: #2b94d6;
---nt-neutral: #6f6f6f;
---nt-secondary: #4c4c4c;
---nt-tertiary: #17a2b8;
---nt-success: #28a745;
---nt-info: #17a2b8;
---nt-warning: #ffc107;
---nt-danger: #dc3545;
+// ---------------------------------------------------------------------------
+// Public theme inputs
+// ---------------------------------------------------------------------------
 
---nt-font-family: "Open Sans", sans-serif;
---nt-font-family-header: var(--nt-font-family);
---nt-font-size: 1rem;
---nt-line-height: 1.4;
---nt-radius: .5rem;
---nt-container-max: 1320px;
+--theme-primary: #2b94d6;
+--theme-accent: #2b94d6;
+--theme-neutral: #6f6f6f;
+--theme-secondary: #4c4c4c;
+--theme-tertiary: #17a2b8;
+--theme-success: #28a745;
+--theme-info: #17a2b8;
+--theme-warning: #ffc107;
+--theme-danger: #dc3545;
 
-// Theme semantics: add only when the same design decision has multiple,
-// independent consumers. Do not mirror component parts as variables.
---theme-corner: var(--nt-radius);
+--theme-font-family: "Open Sans", sans-serif;
+--theme-font-family-header: var(--theme-font-family);
+--theme-font-size: 1rem;
+--theme-line-height: 1.4;
+--theme-radius: .5rem;
+--theme-container-max: 1320px;
+
+// ---------------------------------------------------------------------------
+// Mapping to Nextrap inputs
+// ---------------------------------------------------------------------------
+
+--nt-primary: var(--theme-primary);
+--nt-accent: var(--theme-accent);
+--nt-neutral: var(--theme-neutral);
+--nt-secondary: var(--theme-secondary);
+--nt-tertiary: var(--theme-tertiary);
+--nt-success: var(--theme-success);
+--nt-info: var(--theme-info);
+--nt-warning: var(--theme-warning);
+--nt-danger: var(--theme-danger);
+
+--nt-font-family: var(--theme-font-family);
+--nt-font-family-header: var(--theme-font-family-header);
+--nt-font-size: var(--theme-font-size);
+--nt-line-height: var(--theme-line-height);
+--nt-radius: var(--theme-radius);
+--nt-container-max: var(--theme-container-max);
+
+// ---------------------------------------------------------------------------
+// Additional theme semantics
+// ---------------------------------------------------------------------------
+// Add these only when the same design decision has multiple independent
+// consumers and is not already represented directly by a public theme input.
+
+--theme-corner: var(--theme-radius);
 --theme-corner-small: var(--nt-border-radius-sm);
 --theme-corner-large: var(--nt-border-radius-xl);
 --theme-content-gap: var(--nt-space-4);

--- a/theme/osman/_theme.scss
+++ b/theme/osman/_theme.scss
@@ -7,75 +7,14 @@
 @use "@nextrap/style-typography" as nextrapTypography;
 @use "@nextrap/style-button" as nextrapButton;
 
-$theme: () !default;
-
 // Theme entry: loads all theme-scoped partials below .theme-osman.
-// Always wrap themes classes in where() to avoid specificity issues when using multiple themes on the same page.
+// Keep the scope in :where() so customer/project layers can override it
+// without specificity escalation.
 :where(.theme-osman) {
-  @include nextrapBase.nextrap-theme($theme, (
-    // Theme API defaults / inputs
-    mode: light,
-    density: comfortable,
-    lighten-factor: 40%,
-
-    // Brand colors
-    primary: #2b94d6,
-    accent: #2b94d6,
-    secondary: #4c4c4c,
-    tertiary: #17a2b8,
-    success: #28a745,
-    info: #17a2b8,
-    warning: #ffc107,
-    danger: #dc3545,
-    light: #f8f9fa,
-    dark: #212529,
-    white: #fff,
-    black: #000,
-    neutral: #6f6f6f,
-
-    // Optional semantic overrides for computed colors
-    // text: ...,
-    // header: ...,
-    // surface: ...,
-    // surface-muted: ...,
-    // surface-raised: ...,
-    // text-muted: ...,
-    // border: ...,
-    // focus: ...,
-    // link: ...,
-    text-decoration-link: underline,
-    link-on-dark: #fff,
-
-    // Typography
-    font-family: font.$font-family-base,
-    font-size-base: font.$font-size-base,
-    font-weight-base: 400,
-    line-height-base: 1.4,
-    font-family-header: font.$font-family-base,
-    font-size-header: font.$font-size-header,
-    font-weight-header: 500,
-    line-height-header: 1.2,
-    font-weight-bold: 600,
-    font-size-small: 0.875rem,
-
-    // Shape / container
-    radius: 0.5rem,
-    border-radius-sm: 0.25rem,
-    border-radius-lg: 1rem,
-    container-max: 1320px,
-    container-gutter: var(--nt-space-5),
-
-    // Optional scale overrides
-    // spacing: (...),
-    // spacing-semantic: (...),
-    // text-scales: (...),
-    // header-scales: (...),
-
-    // Legacy / project flags
-    enableFontConfig: true,
-    enableScrollOffset: false,
-    rcs: false
-  ));
+  // Runtime-first Nextrap token graph. Sass emits the relationships; the
+  // concrete design inputs remain CSS custom properties.
+  @include nextrapBase.runtime-theme();
+  @include meta.load-css("./_runtime-settings.scss");
 
   @include nextrapUtils.utils();
   @include nextrapTypography.typography();
@@ -88,7 +27,9 @@ $theme: () !default;
   @include meta.load-css("./html-elements/main/main.scss");
   @include meta.load-css("./elements/tj-content-pane/tj-content-pane.scss");
   @include meta.load-css("./html-elements/a/a.scss");
-  // Element entries.
+
+  // Element entries. Known component variants belong in Nextrap mixins;
+  // precise visual changes belong on exported ::part() selectors.
   @include meta.load-css("./elements/nte-navbar/nte-navbar.scss");
   @include meta.load-css("./elements/nte-navbar-line/nte-navbar-line.scss");
   @include meta.load-css("./elements/nte-nav/nte-nav.scss");
@@ -96,6 +37,7 @@ $theme: () !default;
   @include meta.load-css("./elements/ntl-card-row/ntl-card-row.scss");
   @include meta.load-css("./elements/ntl-2col/ntl-2col.scss");
   @include meta.load-css("./elements/nte-accordion/nte-accordion.scss");
+
   // Theme tools and reusable semantic classes.
   @include meta.load-css("./tools/_icon-grid.scss");
   @include meta.load-css("./classes/_opening-hours.scss");
@@ -106,7 +48,8 @@ $theme: () !default;
   @include meta.load-css("./classes/_warning-heading.scss");
   @include meta.load-css("./classes/_warning-emergency.scss");
   @include meta.load-css("./classes/_aside.scss");
-
-
-
 }
+
+// Explicit scheme selection only changes color-scheme. Derived tokens use
+// light-dark() and therefore react without duplicating a complete token set.
+@include nextrapBase.runtime-scheme-selectors();

--- a/theme/osman/_theme.scss
+++ b/theme/osman/_theme.scss
@@ -23,6 +23,11 @@
   // Shared feature styles from src.
   @include meta.load-css("./../../src/features/_data-kicker.scss");
 
+  // Native HTML defaults. These only opt out when the semantic base styling
+  // class takes ownership (e.g. table.table or ul.list), so utility classes
+  // remain composable.
+  @include meta.load-css("./html-elements/_defaults.scss");
+
   // HTML element pairings that must stay theme-scoped.
   @include meta.load-css("./html-elements/main/main.scss");
   @include meta.load-css("./elements/tj-content-pane/tj-content-pane.scss");

--- a/theme/osman/html-elements/_defaults.scss
+++ b/theme/osman/html-elements/_defaults.scss
@@ -12,11 +12,11 @@
   --nt-table-stripe-bg: color-mix(in srgb, var(--nt-primary) 5%, transparent);
 }
 
-// Native unordered lists use a caret marker unless the explicit `.list`
-// styling API takes ownership. Additional utility classes do not opt out.
+// Native unordered lists reuse the shared Nextrap list base and add only the
+// Osman-specific caret treatment. The explicit `.list` API takes ownership.
 :where(ul:not(.list)) {
-  list-style: none;
-  padding-inline-start: 0;
+  @include elements.list();
+  @include elements.list-unstyled();
 
   > li {
     position: relative;
@@ -36,8 +36,8 @@
   }
 }
 
-// Ordered lists keep native numbering unless `.list` selects an explicit
-// list style. This only normalizes indentation for Osman prose/content.
+// Ordered lists also reuse the shared Nextrap list base; numbering remains
+// native. `.list` explicitly transfers styling ownership to Nextrap classes.
 :where(ol:not(.list)) {
-  padding-inline-start: 1.5em;
+  @include elements.list();
 }

--- a/theme/osman/html-elements/_defaults.scss
+++ b/theme/osman/html-elements/_defaults.scss
@@ -1,0 +1,43 @@
+@use "@nextrap/style-elements" as elements;
+
+// Osman defaults for native content elements.
+// Utility classes remain fully composable. Only the semantic base class opts
+// an element out of the native default because it signals explicit styling.
+
+:where(table:not(.table)) {
+  @include elements.table();
+  @include elements.table-striped();
+
+  --nt-border-color: var(--nt-border);
+  --nt-table-stripe-bg: color-mix(in srgb, var(--nt-primary) 5%, transparent);
+}
+
+// Native unordered lists use a caret marker unless the explicit `.list`
+// styling API takes ownership. Additional utility classes do not opt out.
+:where(ul:not(.list)) {
+  list-style: none;
+  padding-inline-start: 0;
+
+  > li {
+    position: relative;
+    padding-inline-start: 1.25em;
+
+    &::before {
+      content: "›";
+      position: absolute;
+      inset-inline-start: 0;
+      color: var(--nt-primary);
+      font-weight: var(--nt-font-weight-bold, 600);
+    }
+  }
+
+  ul {
+    margin-block-start: var(--nt-space-2);
+  }
+}
+
+// Ordered lists keep native numbering unless `.list` selects an explicit
+// list style. This only normalizes indentation for Osman prose/content.
+:where(ol:not(.list)) {
+  padding-inline-start: 1.5em;
+}


### PR DESCRIPTION
## Summary

Companion to nextrap/nextrap-monorepo#92.

Migrates the Osman theme entry to the proposed runtime-first Nextrap theme API and documents the ThemeJS2 layering model.

### What changes
- replaces the large compile-time Osman theme map with `nextrapBase.runtime-theme()`
- moves actual design inputs into `_runtime-settings.scss`
- introduces a deliberately small semantic layer (`--theme-corner*`, content/section gaps, border, shadow)
- keeps component-specific styling in component partials / `::part()` rather than creating component-specific theme variables
- adds explicit light/dark scheme selection without duplicating a complete dark token set
- adds `docs/theme-architecture.md` with decision rules for base tokens, semantics, mixins, parts and customer exceptions

### Design rule
`--nt-*` describes the design scale; the small `--theme-*` set describes cross-component design language; mixins describe known component variants; `::part()` remains the precise and discoverable customization API.

### Dependency
This PR depends on nextrap/nextrap-monorepo#92 (new `runtime-theme()` and `runtime-scheme-selectors()` mixins) and should be merged only after a compatible `@nextrap/style-base` release is available.